### PR TITLE
oauth middlewware 指定home_url后出错

### DIFF
--- a/lib/oauth_middleware.js
+++ b/lib/oauth_middleware.js
@@ -118,7 +118,8 @@ module.exports = function oauth(options) {
     options = options || {};
   }
 	if (options.home_url) {
-	  options.home_url = home_url.replace(/\/+$/, '');
+	   options.home_url = options.home_url.replace(/\/+$/, '');	
+	  //options.home_url = home_url.replace(/\/+$/, '');
 	}
 	options.login_path = options.login_path || '/oauth';
   options.logout_path = options.logout_path || '/ouath/logout';


### PR DESCRIPTION
options.home_url = home_url.replace(/\/+$/, '');
}
后面的home_url应该是忘记加options了吧？
