### PR TITLE
github oauth验证现在必须要有user-agent请求头，否则报错

### DIFF
--- a/lib/tbase.js
+++ b/lib/tbase.js
@@ -687,6 +687,9 @@ TBase.prototype.verify_credentials = function (user, callback) {
     user: user,
     playload: 'user',
     request_method: 'verify_credentials'
+    headers: {
+      'User-Agent': 'Weibo app'
+    }
   };
   var url = this.config.verify_credentials;
   this.send_request(url, params, callback);

--- a/lib/tbase.js
+++ b/lib/tbase.js
@@ -16,8 +16,7 @@ var utils = require('./utils');
 var OAuth = require('./oauth');
 var emoji = require('emoji');
 var EventProxy = require('eventproxy');
-var fs = require('fs');
-var path = require('path');
+var pkg = require('../package');
 
 /**
  * TAPI Base class, support OAuth v1.0
@@ -684,21 +683,17 @@ TBase.prototype.convert_friendship = function (data) {
  */
 
 TBase.prototype.verify_credentials = function (user, callback) {
-  fs.readFile(path.resolve( __dirname ,'../package.json'), 'utf8', function(err, data) {
-    if (err) return callback(err);
-    var pkg = JSON.parse(data);
-    var params = {
-      type: 'GET',
-      user: user,
-      playload: 'user',
-      request_method: 'verify_credentials',
-      headers: {
-        'User-Agent': 'node-weibo/' + pkg.version
-      }
-    };
-    var url = this.config.verify_credentials;
-    this.send_request(url, params, callback);
-  }.bind(this));
+  var params = {
+    type: 'GET',
+    user: user,
+    playload: 'user',
+    request_method: 'verify_credentials',
+    headers: {
+      'User-Agent': 'node-weibo/' + pkg.version
+    }
+  };
+  var url = this.config.verify_credentials;
+  this.send_request(url, params, callback);
   return this;
 };
 

--- a/lib/tbase.js
+++ b/lib/tbase.js
@@ -16,6 +16,8 @@ var utils = require('./utils');
 var OAuth = require('./oauth');
 var emoji = require('emoji');
 var EventProxy = require('eventproxy');
+var fs = require('fs');
+var path = require('path');
 
 /**
  * TAPI Base class, support OAuth v1.0
@@ -682,19 +684,24 @@ TBase.prototype.convert_friendship = function (data) {
  */
 
 TBase.prototype.verify_credentials = function (user, callback) {
-  var params = {
-    type: 'GET',
-    user: user,
-    playload: 'user',
-    request_method: 'verify_credentials'
-    headers: {
-      'User-Agent': 'Weibo app'
-    }
-  };
-  var url = this.config.verify_credentials;
-  this.send_request(url, params, callback);
+  fs.readFile(path.resolve( __dirname ,'../package.json'), 'utf8', function(err, data) {
+    if (err) return callback(err);
+    var pkg = JSON.parse(data);
+    var params = {
+      type: 'GET',
+      user: user,
+      playload: 'user',
+      request_method: 'verify_credentials',
+      headers: {
+        'User-Agent': 'node-weibo/' + pkg.version
+      }
+    };
+    var url = this.config.verify_credentials;
+    this.send_request(url, params, callback);
+  }.bind(this));
   return this;
 };
+
 
 TBase.prototype.user_show = function (user, uid, screen_name, callback) {
   var data = {};


### PR DESCRIPTION
```
Request forbidden by administrative rules. Please make sure your request has a User-Agent header (http://developer.github.com/v3/#user-agent-required). Check https://developer.github.com for other possible causes.
RemoteSocketClosedError: Remote socket was terminated before `response.end()` was called, GET https://api.github.com/user
    at IncomingMessage.<anonymous> (/Users/chemzqm/work/weitalk/node_modules/weibo/node_modules/urllib/lib/urllib.js:346:15)
    at IncomingMessage.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:920:16
    at process._tickCallback (node.js:415:13)
```

请修复一下
