### PR TITLE
fix an err in oauth midware

### DIFF
--- a/lib/oauth_middleware.js
+++ b/lib/oauth_middleware.js
@@ -141,10 +141,10 @@ module.exports = function oauth(options) {
   return function (req, res, next) {
     if (req.url.indexOf(options.callbackPath) === 0) {
       oauthCallback(req, res, next, options);
-    } else if (req.url.indexOf(options.loginPath) === 0) {
-      login(req, res, next, options);
     } else if (req.url.indexOf(options.logoutPath) === 0) {
       logout(req, res, next, options);
+    } else if (req.url.indexOf(options.loginPath) === 0) {
+      login(req, res, next, options);
     } else {
       next();
     }


### PR DESCRIPTION
when requesting /oauth/logout, the relevant if branch of "logoutPath" won't get reached.
because the url will match /oauth , the if branch of "loginPath" will intercept the execution.